### PR TITLE
[Issue #1] Fix compatibilty with Japanese titles

### DIFF
--- a/psx_scraper.py
+++ b/psx_scraper.py
@@ -39,7 +39,7 @@ except FileNotFoundError:
 
 
 def get_game_name(filename):
-    gamename = ''
+    gamename = b''
     with open(filename, 'rb') as eboot:
         # check for PBP header
         if not eboot.read(4).decode() == '\x00' + 'PBP':
@@ -48,13 +48,14 @@ def get_game_name(filename):
             eboot.seek(int('0x358', base=16))
             while True:
                 current_byte = eboot.read(1)
-                if current_byte == '\x00':
+                if current_byte == b'\x00':
                     break
                 else:
                     try:
-                        gamename += current_byte.decode()
+                        gamename += current_byte
                     except UnicodeDecodeError:
                         break
+    gamename = gamename.decode()
     if len(gamename) > 31:
         return gamename.replace(' ', '')[:21].replace('\x00', '')
     else:


### PR DESCRIPTION
Previously Japanese game titles could not be read because the read loop expected a 1:1 byte:char relationship.  Japanese characters are made up of multiple bytes, so the control flow was updated to reflect this.  Tested on Puyo Puyo Box EBOOT.PBP.